### PR TITLE
Allow aspire project to use launchSettings.json

### DIFF
--- a/Rsp.QuestionSetPortal/Properties/launchSettings.json
+++ b/Rsp.QuestionSetPortal/Properties/launchSettings.json
@@ -1,29 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:40629",
-      "sslPort": 44345
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Umbraco.Web.UI": {
+    "Rsp.QuestionSetPortal": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44345;http://localhost:40629",
+      "launchUrl": "umbraco",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }      
+      }
     }
   }
 }


### PR DESCRIPTION
- Allow aspire project to use launchSettings.json instead of specifying the port in aspire